### PR TITLE
feat: v0.7.0 updates - page range selection, security improvements, and maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,21 @@ Convert PDFs with a focus on academic papers into human-and-LLM-friendly **text-
 
 ### Credits
 
-`paper2llm` was written by [Luigi Acerbi](https://lacerbi.github.io/) using [Claude 3.7 Sonnet](https://www.anthropic.com/news/claude-3-7-sonnet) and Athanor.
-You can follow me on [X](https://x.com/AcerbiLuigi) and [Bluesky](https://bsky.app/profile/lacerbi.bsky.social).
+`paper2llm` was written by [Luigi Acerbi](https://lacerbi.github.io/) using [Claude](https://www.anthropic.com/claude) and [Claude Code](https://claude.ai/code).
+You can follow me on [X](https://x.com/AcerbiLuigi), [LinkedIn](https://www.linkedin.com/in/luigi-acerbi-719b492/), and [Bluesky](https://bsky.app/profile/lacerbi.bsky.social).
 
 ## Image Descriptions and Vision Models
 
-After the OCR step, figures are converted to a Markdown text description using vision models such as Mistral AI's [Mistral Small](https://mistral.ai/news/mistral-small-3-1) or Google's [Gemini 2.5 Flash](https://deepmind.google/technologies/gemini/flash/). You can select the desired vision model via a dropdown menu, based on which API keys you entered.
+After the OCR step, figures are converted to a Markdown text description using vision models such as Mistral AI's [Mistral Small 3.1](https://mistral.ai/news/mistral-small-3-1) or Google's [Gemini 3 Flash](https://blog.google/products/gemini/gemini-3-flash/). You can select the desired vision model via a dropdown menu, based on which API keys you entered.
 
 <details>
 <summary>Notes on vision models choice.</summary>
-  
+
 - Both Mistral AI and Google Gemini offer a **free API tier**.
-- [**Gemini 2.5 Flash**](https://deepmind.google/technologies/gemini/flash/) is our currently recommended model for `paper2llm`. It is included in the [Gemini API free tier](https://ai.google.dev/gemini-api/docs/pricing) or otherwise very cheap, and shows very good performance.
-- If you prefer to stick to only using the Mistral AI API, the default free Mistral AI model, [Mistral Small](https://mistral.ai/news/mistral-small-3-1), is a top-performing model in its size category and works generally well.
-- [Pixtral Large](https://mistral.ai/en/news/pixtral-large) may work better for understanding complex diagrams and concepts, but it's a premier model; the API call is not rejected, but it might redirect to a free model if no API credits are available.
-- Other premium models such as OpenAI's GPT-4o, Anthropic's Claude Sonnet 3.7 or Google Gemini 2.0 Pro might work better for complex figures, but beware of API costs.
+- [**Gemini 3 Flash**](https://blog.google/products/gemini/gemini-3-flash/) is our currently recommended model for `paper2llm`. It is included in the [Gemini API free tier](https://ai.google.dev/gemini-api/docs/pricing) or otherwise very cheap, and shows very good performance.
+- If you prefer to stick to only using the Mistral AI API, the default free Mistral AI model, [Mistral Small 3.1](https://mistral.ai/news/mistral-small-3-1), is a top-performing model in its size category and works generally well.
+- [Mistral Large 3](https://mistral.ai/news/mistral-large-3) or [Pixtral Large](https://mistral.ai/news/pixtral-large) may work better for understanding complex diagrams and concepts, but they are premier models.
+- Other premium models such as OpenAI's GPT-5, Anthropic's Claude 4.5 Sonnet, or Google Gemini 3 Pro might work better for complex figures, but beware of API costs.
 </details>
 
 ## Disclaimers
@@ -39,6 +39,13 @@ After the OCR step, figures are converted to a Markdown text description using v
 - We have no affiliation or financial relationship with Mistral AI, besides sympathy for a European AI company and appreciation for their AI models, nor with any other LLM providers.
 - This is a _research preview_, as they say. Use at your own risk and with all the caveats of modern AI and LLM usage.
 - In particular, image descriptions might be off in clear or subtle ways and you should double-check and fix them as needed.
+
+### Privacy and Legal
+
+- **Data transmission:** When you use `paper2llm`, your PDF content is sent to third-party API providers (Mistral AI, OpenAI, Google, Anthropic) for processing. By using this tool, you agree to the terms of service and privacy policies of these providers.
+- **No server-side storage:** `paper2llm` runs entirely in your browser. We do not store, collect, or have access to your documents, API keys, or converted files.
+- **Your responsibility:** You are solely responsible for ensuring you have the right to process and convert any documents you upload. Do not upload confidential, proprietary, or sensitive documents unless you understand and accept the data handling practices of the API providers.
+- **API provider policies:** Please review the data usage policies of the respective providers, as some may use API inputs for model training unless you opt out. See [Mistral AI](https://mistral.ai/terms/), [OpenAI](https://openai.com/policies/), [Google](https://ai.google.dev/terms), and [Anthropic](https://www.anthropic.com/legal/privacy) for details.
 
 ## License
 

--- a/paper2llm-web/package.json
+++ b/paper2llm-web/package.json
@@ -1,10 +1,12 @@
 {
   "name": "paper2llm",
-  "version": "0.6.4",
+  "version": "0.7.0",
+  "lastUpdated": "2025-12-29",
   "private": true,
   "homepage": "https://lacerbi.github.io/paper2llm",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "pdf-lib": "^1.17.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^6.4.7",

--- a/paper2llm-web/src/adapters/web/api-storage/internal/crypto-utils.ts
+++ b/paper2llm-web/src/adapters/web/api-storage/internal/crypto-utils.ts
@@ -2,7 +2,7 @@
 // Provides authenticated encryption (AES-GCM), key derivation (PBKDF2), and secure
 // random number generation with appropriate encoding utilities and fallbacks.
 
-import { EncryptedKeyData, ValidationInfo, CRYPTO_ALGORITHMS, CRYPTO_DEFAULTS } from "./interfaces";
+import { EncryptedKeyData, CRYPTO_ALGORITHMS, CRYPTO_DEFAULTS } from "./interfaces";
 import { ApiKeyStorageError } from "../errors";
 import { ApiProvider } from "../api-key-storage";
 

--- a/paper2llm-web/src/adapters/web/api-storage/internal/expiration-service.ts
+++ b/paper2llm-web/src/adapters/web/api-storage/internal/expiration-service.ts
@@ -7,7 +7,6 @@ import {
   ApiProvider,
   ApiKeyStorageType,
 } from "../api-key-storage";
-import { ApiKeyProvider } from "./interfaces";
 import { StorageOperations } from "./storage-operations";
 
 /**

--- a/paper2llm-web/src/adapters/web/api-storage/internal/interfaces.ts
+++ b/paper2llm-web/src/adapters/web/api-storage/internal/interfaces.ts
@@ -5,7 +5,6 @@ import {
   ApiProvider,
   ApiKeyStorageType,
   ApiKeyExpiration,
-  ApiKeyStorageOptions,
 } from "../api-key-storage";
 
 /**

--- a/paper2llm-web/src/adapters/web/api-storage/internal/providers/anthropic-provider.ts
+++ b/paper2llm-web/src/adapters/web/api-storage/internal/providers/anthropic-provider.ts
@@ -2,7 +2,6 @@
 // Extends BaseProvider with Anthropic-specific behavior and validation patterns.
 
 import { BaseProvider } from "./base-provider";
-import { ApiProvider } from "../../api-key-storage";
 
 /**
  * Provider implementation for Anthropic API keys

--- a/paper2llm-web/src/adapters/web/api-storage/internal/providers/gemini-provider.ts
+++ b/paper2llm-web/src/adapters/web/api-storage/internal/providers/gemini-provider.ts
@@ -2,7 +2,6 @@
 // Extends BaseProvider with Gemini-specific behavior and validation patterns.
 
 import { BaseProvider } from "./base-provider";
-import { ApiProvider } from "../../api-key-storage";
 
 /**
  * Provider implementation for Google Gemini API keys

--- a/paper2llm-web/src/adapters/web/api-storage/internal/providers/index.ts
+++ b/paper2llm-web/src/adapters/web/api-storage/internal/providers/index.ts
@@ -19,7 +19,6 @@ import { MistralProvider } from './mistral-provider';
 import { OpenAIProvider } from './openai-provider';
 import { GeminiProvider } from './gemini-provider';
 import { AnthropicProvider } from './anthropic-provider';
-import { BaseProvider } from './base-provider';
 
 // Export base provider class and implementations
 export { BaseProvider } from './base-provider';

--- a/paper2llm-web/src/adapters/web/api-storage/internal/providers/mistral-provider.ts
+++ b/paper2llm-web/src/adapters/web/api-storage/internal/providers/mistral-provider.ts
@@ -2,7 +2,6 @@
 // Extends BaseProvider with Mistral-specific behavior and validation patterns.
 
 import { BaseProvider } from "./base-provider";
-import { ApiProvider } from "../../api-key-storage";
 
 /**
  * Provider implementation for Mistral API keys

--- a/paper2llm-web/src/adapters/web/api-storage/internal/providers/openai-provider.ts
+++ b/paper2llm-web/src/adapters/web/api-storage/internal/providers/openai-provider.ts
@@ -2,7 +2,6 @@
 // Extends BaseProvider with OpenAI-specific behavior and validation patterns.
 
 import { BaseProvider } from "./base-provider";
-import { ApiProvider } from "../../api-key-storage";
 
 /**
  * Provider implementation for OpenAI API keys

--- a/paper2llm-web/src/adapters/web/api-storage/internal/storage-operations.ts
+++ b/paper2llm-web/src/adapters/web/api-storage/internal/storage-operations.ts
@@ -4,7 +4,6 @@
 
 import { ApiKeyStorageType, ApiProvider } from "../api-key-storage";
 import { StorageKeyPatterns } from "./interfaces";
-import { ApiKeyProvider } from "./interfaces";
 
 /**
  * Interface for storage operations service

--- a/paper2llm-web/src/adapters/web/api-storage/internal/web-api-key-storage.ts
+++ b/paper2llm-web/src/adapters/web/api-storage/internal/web-api-key-storage.ts
@@ -15,10 +15,7 @@ import { ApiKeyStorageError } from "../errors";
 import {
   ProviderRegistry,
   StorageKeyPatterns,
-  ApiKeyProvider,
   createDefaultStorageKeyPatterns,
-  CRYPTO_ALGORITHMS,
-  CRYPTO_DEFAULTS,
 } from "./interfaces";
 import { passwordValidation } from "./password-utils";
 import { cryptoUtils } from "./crypto-utils";

--- a/paper2llm-web/src/core/domain-handlers/generic-handler.ts
+++ b/paper2llm-web/src/core/domain-handlers/generic-handler.ts
@@ -269,7 +269,7 @@ export function createAclConfig(): RepositoryConfig {
     pdfTransformRules: [
       {
         // Ensure URL ends with .pdf
-        pattern: /\/([^\/]+)$/,
+        pattern: /\/([^/]+)$/,
         replacement: (match, urlObj) => {
           return `/${match[1]}.pdf`;
         }
@@ -278,7 +278,7 @@ export function createAclConfig(): RepositoryConfig {
     filenameRules: [
       {
         // Extract paper ID from pathname
-        pattern: /\/([^\/]+?)(?:\.pdf)?$/,
+        pattern: /\/([^/]+?)(?:\.pdf)?$/,
         template: 'acl-$1.pdf'
       }
     ]
@@ -356,19 +356,19 @@ export function createNipsConfig(): RepositoryConfig {
     pdfTransformRules: [
       {
         // Convert hash URLs to file URLs
-        pattern: /(\/paper(?:_files\/paper)?\/\d{4})\/hash\/([^\/]+)-Abstract\.html/,
+        pattern: /(\/paper(?:_files\/paper)?\/\d{4})\/hash\/([^/]+)-Abstract\.html/,
         replacement: '$1/file/$2-Paper.pdf'
       }
     ],
     filenameRules: [
       {
         // Extract year and hash for filename
-        pattern: /\/paper(?:_files\/paper)?\/(\d{4})\/(?:hash|file)\/([^\/\-]+)/,
+        pattern: /\/paper(?:_files\/paper)?\/(\d{4})\/(?:hash|file)\/([^/-]+)/,
         template: 'neurips-$1-$2.pdf'
       },
       {
         // Fallback pattern just for hash
-        pattern: /\/(?:hash|file)\/([^\/\-]+)/,
+        pattern: /\/(?:hash|file)\/([^/-]+)/,
         template: 'neurips-$1.pdf'
       }
     ]

--- a/paper2llm-web/src/core/image-service.ts
+++ b/paper2llm-web/src/core/image-service.ts
@@ -2,15 +2,14 @@
 // Delegates to provider-specific implementations through a factory.
 // Maintains backward compatibility while supporting multiple providers.
 
-import { 
- ApiProvider, 
- ImageService, 
- OcrImage, 
- ProgressReporter, 
- VisionModelInfo 
+import {
+ ApiProvider,
+ ImageService,
+ OcrImage,
+ ProgressReporter,
+ VisionModelInfo
 } from "../types/interfaces";
 import { imageServiceFactory } from "./image-services/image-service-factory";
-import { ImageProcessingError } from "./image-services/base-image-service";
 
 /**
 * Re-export the custom error class

--- a/paper2llm-web/src/core/image-services/anthropic-image-service.ts
+++ b/paper2llm-web/src/core/image-services/anthropic-image-service.ts
@@ -1,7 +1,7 @@
 // AI Summary: Anthropic-specific implementation of the image description service.
 // Handles API communication with Anthropic's Claude models for image analysis using the official SDK.
 // Includes model validation, error handling, and response processing.
-// Uses Claude 3.7 Sonnet and 3.5 Haiku models with appropriate API formatting.
+// Uses Claude 4.5 Sonnet and Haiku models with appropriate API formatting.
 
 import Anthropic from '@anthropic-ai/sdk';
 import { ContentBlockParam } from '@anthropic-ai/sdk/resources/messages';
@@ -19,24 +19,20 @@ export class AnthropicImageService extends BaseImageService {
   // Available Anthropic Vision models
   private readonly modelInfos: VisionModelInfo[] = [
     {
-      id: "claude-3-7-sonnet-latest",
-      name: "Claude 3.7 Sonnet",
-      description: "Intelligence and speed for high-quality image analysis",
+      id: "claude-sonnet-4-5-20250929",
+      name: "Claude 4.5 Sonnet",
+      description: "Smart model for complex agents and high-quality image analysis",
       provider: "anthropic",
       maxTokens: this.DEFAULT_PREMIUM_MODEL_TOKENS,
     },
     {
-      id: "claude-3-5-haiku-latest",
-      name: "Claude 3.5 Haiku",
-      description: "Fastest model for efficient image understanding",
+      id: "claude-haiku-4-5-20251001",
+      name: "Claude 4.5 Haiku",
+      description: "Fastest model with near-frontier intelligence",
       provider: "anthropic",
       maxTokens: this.DEFAULT_FAST_MODEL_TOKENS,
     },
   ];
-
-  constructor() {
-    super();
-  }
 
   /**
    * Returns the available Anthropic vision models
@@ -55,7 +51,7 @@ export class AnthropicImageService extends BaseImageService {
     if (provider !== "anthropic") {
       return "";
     }
-    return "claude-3-5-haiku-latest"; // Use haiku as the default model (balance of speed/quality)
+    return "claude-haiku-4-5-20251001"; // Use Haiku 4.5 as the default model (balance of speed/quality)
   }
 
   /**

--- a/paper2llm-web/src/core/image-services/gemini-image-service.ts
+++ b/paper2llm-web/src/core/image-services/gemini-image-service.ts
@@ -18,10 +18,26 @@ export class GeminiImageService extends BaseImageService {
   // Available Gemini Vision models
   private readonly modelInfos: VisionModelInfo[] = [
     {
+      id: "gemini-3-pro-preview",
+      name: "Gemini 3 Pro",
+      description:
+        "Most advanced reasoning model for complex multimodal tasks",
+      provider: "gemini",
+      maxTokens: 65536,
+    },
+    {
+      id: "gemini-3-flash-preview",
+      name: "Gemini 3 Flash",
+      description:
+        "Balanced model with frontier intelligence built for speed and scale",
+      provider: "gemini",
+      maxTokens: 65536,
+    },
+    {
       id: "gemini-2.5-pro",
       name: "Gemini 2.5 Pro",
       description:
-        "Most advanced Gemini model for complex reasoning and multimodal tasks",
+        "Advanced Gemini model for complex reasoning and multimodal tasks",
       provider: "gemini",
       maxTokens: 65536,
     },
@@ -40,20 +56,6 @@ export class GeminiImageService extends BaseImageService {
         "Smallest and most cost effective model, built for at scale usage",
       provider: "gemini",
       maxTokens: 64000,
-    },
-    {
-      id: "gemini-2.0-flash",
-      name: "Gemini 2.0 Flash",
-      description: "High-performance model with multimodal capabilities",
-      provider: "gemini",
-      maxTokens: 8192,
-    },
-    {
-      id: "gemini-2.0-flash-lite",
-      name: "Gemini 2.0 Flash Lite",
-      description: "Lightweight version of Gemini 2.0 Flash",
-      provider: "gemini",
-      maxTokens: 8192,
     },
   ];
 
@@ -79,7 +81,7 @@ export class GeminiImageService extends BaseImageService {
     if (provider !== "gemini") {
       return "";
     }
-    return "gemini-2.5-flash"; // Use flash 2.5 as the default model
+    return "gemini-3-flash-preview"; // Use Gemini 3 Flash as the default model
   }
 
   /**

--- a/paper2llm-web/src/core/image-services/mistral-image-service.ts
+++ b/paper2llm-web/src/core/image-services/mistral-image-service.ts
@@ -18,24 +18,23 @@ export class MistralImageService extends BaseImageService {
   // Available Mistral Vision models
   private readonly modelInfos: VisionModelInfo[] = [
     {
-      id: "pixtral-12b-2409",
-      name: "Pixtral",
-      description: "Standard vision model for simple use cases (free tier)",
+      id: "mistral-large-3-25-12",
+      name: "Mistral Large 3",
+      description: "State-of-the-art multimodal model for complex tasks",
+      provider: "mistral",
+      maxTokens: this.DEFAULT_PREMIUM_MODEL_TOKENS,
+    },
+    {
+      id: "mistral-small-3-1-25-03",
+      name: "Mistral Small 3.1",
+      description: "Fast, efficient model with image understanding",
       provider: "mistral",
       maxTokens: this.DEFAULT_FAST_MODEL_TOKENS,
     },
     {
-      id: "mistral-small-latest",
-      name: "Mistral Small",
-      description:
-        "A new leader among small models with image understanding (free tier)",
-      provider: "mistral",
-      maxTokens: this.DEFAULT_FAST_MODEL_TOKENS,
-    },
-    {
-      id: "pixtral-large-latest",
+      id: "pixtral-large-24-11",
       name: "Pixtral Large",
-      description: "Frontier-class multimodal model (premier tier)",
+      description: "Frontier-class model designed for image understanding",
       provider: "mistral",
       maxTokens: this.DEFAULT_PREMIUM_MODEL_TOKENS,
     },
@@ -63,7 +62,7 @@ export class MistralImageService extends BaseImageService {
     if (provider !== "mistral") {
       return "";
     }
-    return "mistral-small-latest";
+    return "mistral-small-3-1-25-03"; // Use Mistral Small 3.1 as default (balance of speed/quality)
   }
 
   /**

--- a/paper2llm-web/src/core/image-services/openai-image-service.ts
+++ b/paper2llm-web/src/core/image-services/openai-image-service.ts
@@ -18,11 +18,18 @@ export class OpenAIImageService extends BaseImageService {
   // Available OpenAI Vision models
   private readonly modelInfos: VisionModelInfo[] = [
     {
-      id: "gpt-4o",
-      name: "GPT-4o",
-      description: "Latest vision model with high-quality image understanding",
+      id: "gpt-5",
+      name: "GPT-5",
+      description: "Advanced model for coding, reasoning, and image analysis",
       provider: "openai",
       maxTokens: this.DEFAULT_PREMIUM_MODEL_TOKENS,
+    },
+    {
+      id: "gpt-5-mini",
+      name: "GPT-5 Mini",
+      description: "Fast, cost-efficient model with vision capabilities",
+      provider: "openai",
+      maxTokens: this.DEFAULT_FAST_MODEL_TOKENS,
     },
   ];
 
@@ -48,7 +55,7 @@ export class OpenAIImageService extends BaseImageService {
     if (provider !== "openai") {
       return "";
     }
-    return "gpt-4o";
+    return "gpt-5-mini"; // Use GPT-5 Mini as default (balance of speed/cost)
   }
 
   /**

--- a/paper2llm-web/src/core/ocr-service.ts
+++ b/paper2llm-web/src/core/ocr-service.ts
@@ -118,16 +118,24 @@ export class MistralOcrService implements OcrService {
         });
       }
       
+      // Build request payload
+      const payload: Record<string, unknown> = {
+        model: options.model || this.defaultModel,
+        document: {
+          type: 'document_url',
+          document_url: url
+        },
+        include_image_base64: options.includeImageBase64 !== false
+      };
+
+      // Add pages parameter if specified (for URL-based PDFs)
+      if (options.pages && options.pages.length > 0) {
+        payload.pages = options.pages;
+      }
+
       const response = await this.axiosInstance.post(
         '/ocr',
-        {
-          model: options.model || this.defaultModel,
-          document: {
-            type: 'document_url',
-            document_url: url
-          },
-          include_image_base64: options.includeImageBase64 !== false
-        },
+        payload,
         {
           headers: {
             'Content-Type': 'application/json',
@@ -155,13 +163,13 @@ export class MistralOcrService implements OcrService {
           message: 'Processing OCR results'
         });
       }
-      
+
       const ocrResult = this.processResponse(response);
-      
+
       if (progressReporter) {
         progressReporter.reportComplete(ocrResult);
       }
-      
+
       return ocrResult;
     } catch (error) {
       // Handle and transform error with the URL for context
@@ -364,17 +372,25 @@ export class MistralOcrService implements OcrService {
         processUrl = url.replace(/\/(abs|html)\//, '/pdf/');
         console.log(`Direct processing with converted arXiv URL: ${processUrl}`);
       }
-      
+
+      // Build request payload
+      const payload: Record<string, unknown> = {
+        model: options.model || this.defaultModel,
+        document: {
+          type: 'document_url',
+          document_url: processUrl
+        },
+        include_image_base64: options.includeImageBase64 !== false
+      };
+
+      // Add pages parameter if specified (for URL-based PDFs)
+      if (options.pages && options.pages.length > 0) {
+        payload.pages = options.pages;
+      }
+
       const response = await this.axiosInstance.post(
         '/ocr',
-        {
-          model: options.model || this.defaultModel,
-          document: {
-            type: 'document_url',
-            document_url: processUrl
-          },
-          include_image_base64: options.includeImageBase64 !== false
-        },
+        payload,
         {
           headers: {
             'Content-Type': 'application/json',

--- a/paper2llm-web/src/core/pdf-to-md.ts
+++ b/paper2llm-web/src/core/pdf-to-md.ts
@@ -1,26 +1,27 @@
 // AI Summary: Main orchestration pipeline for converting PDFs to Markdown.
 // Coordinates file handling, OCR processing, image description, and Markdown generation with progress tracking.
 
-import { 
-  PdfFile, 
-  OcrOptions, 
-  MarkdownOptions, 
+import {
+  PdfFile,
+  PdfFileWithPageInfo,
+  OcrOptions,
+  MarkdownOptions,
   PdfToMdResult,
   ProgressReporter,
-  ApiProvider,
-  BibTeXTitleValidation
+  ApiProvider
 } from '../types/interfaces';
 import { mistralOcrService } from './ocr-service';
 import { markdownProcessor } from './markdown-processor';
 import { multiProviderImageService } from './image-service';
-import { generateBibTeXFromMarkdown, BibTeXGenerationResult } from './utils/bibtex-generator';
+import { generateBibTeXFromMarkdown } from './utils/bibtex-generator';
+import { extractPdfPages, pageRangeToMistralPages } from './utils/pdf-page-utils';
 
 export class PdfToMdService {
   /**
    * Converts a PDF file to enhanced Markdown
    */
   public async convertPdfToMarkdown(
-    file: PdfFile,
+    file: PdfFileWithPageInfo | PdfFile,
     ocrApiKey: string,
     visionApiKey: string,
     ocrOptions: OcrOptions = {},
@@ -38,11 +39,62 @@ export class PdfToMdService {
           message: 'Starting PDF to Markdown conversion'
         });
       }
-      
+
+      // Handle page range selection with dual strategy
+      let processFile: PdfFile = file;
+      let processOcrOptions = { ...ocrOptions };
+      const fileWithPageInfo = file as PdfFileWithPageInfo;
+
+      if (fileWithPageInfo.selectedPageRange && fileWithPageInfo.pageCount && fileWithPageInfo.pageCount > 1) {
+        const { startPage, endPage } = fileWithPageInfo.selectedPageRange;
+        const isFullRange = startPage === 1 && endPage === fileWithPageInfo.pageCount;
+
+        if (!isFullRange) {
+          if (progressReporter) {
+            progressReporter.reportProgress({
+              stage: 'preparing',
+              progress: 2,
+              message: `Preparing pages ${startPage}-${endPage} of ${fileWithPageInfo.pageCount}`
+            });
+          }
+
+          if (file.directProcessUrl && file.originalUrl) {
+            // For URL-based PDFs: use Mistral's pages parameter
+            processOcrOptions.pages = pageRangeToMistralPages(startPage, endPage);
+          } else if (file.source === 'upload') {
+            // For local uploads: extract pages into new PDF (privacy-preserving)
+            const extractedBlob = await extractPdfPages(
+              file.content,
+              startPage,
+              endPage
+            );
+
+            processFile = {
+              ...file,
+              content: extractedBlob,
+              size: extractedBlob.size
+            };
+          } else if (file.source === 'url' && !file.directProcessUrl) {
+            // For fetched URLs (we have the blob): extract pages
+            const extractedBlob = await extractPdfPages(
+              file.content,
+              startPage,
+              endPage
+            );
+
+            processFile = {
+              ...file,
+              content: extractedBlob,
+              size: extractedBlob.size
+            };
+          }
+        }
+      }
+
       const ocrResult = await mistralOcrService.processPdf(
-        file,
+        processFile,
         ocrApiKey,
-        ocrOptions,
+        processOcrOptions,
         progressReporter
       );
       

--- a/paper2llm-web/src/core/utils/bibtex-generator.ts
+++ b/paper2llm-web/src/core/utils/bibtex-generator.ts
@@ -100,25 +100,6 @@ const DEFAULT_OPTIONS: BibTeXGenerationOptions = {
 };
 
 /**
- * Safely extracts a year from a date string or returns the current year
- *
- * @param dateStr The date string to extract year from
- * @returns The extracted year or current year as fallback
- */
-function extractYearFromDate(dateStr?: string): string {
-  if (!dateStr) {
-    return new Date().getFullYear().toString();
-  }
-
-  try {
-    const date = new Date(dateStr);
-    return date.getFullYear().toString();
-  } catch (e) {
-    return new Date().getFullYear().toString();
-  }
-}
-
-/**
  * Sanitizes text for use in BibTeX entries by escaping special characters
  *
  * @param text The text to sanitize

--- a/paper2llm-web/src/core/utils/pdf-page-utils.ts
+++ b/paper2llm-web/src/core/utils/pdf-page-utils.ts
@@ -1,0 +1,100 @@
+// AI Summary: Utility functions for PDF page operations using pdf-lib.
+// Handles page counting for both local files and URL-fetched PDFs, and page extraction for local uploads.
+
+import { PDFDocument } from 'pdf-lib';
+
+/**
+ * Result of page count detection
+ */
+export interface PageCountResult {
+  pageCount: number;
+  error?: string;
+}
+
+/**
+ * Gets the page count from a PDF file (Blob, File, or ArrayBuffer)
+ * @param content The PDF content
+ * @returns Page count result
+ */
+export async function getPdfPageCount(
+  content: File | Blob | ArrayBuffer
+): Promise<PageCountResult> {
+  try {
+    let arrayBuffer: ArrayBuffer;
+
+    if (content instanceof ArrayBuffer) {
+      arrayBuffer = content;
+    } else {
+      arrayBuffer = await content.arrayBuffer();
+    }
+
+    const pdfDoc = await PDFDocument.load(arrayBuffer, {
+      ignoreEncryption: true,
+    });
+
+    return { pageCount: pdfDoc.getPageCount() };
+  } catch (error) {
+    return {
+      pageCount: 0,
+      error: error instanceof Error ? error.message : 'Failed to read PDF'
+    };
+  }
+}
+
+/**
+ * Extracts specified pages from a PDF and returns a new PDF blob
+ * @param content Original PDF content
+ * @param startPage Start page (1-indexed, inclusive)
+ * @param endPage End page (1-indexed, inclusive)
+ * @returns New PDF blob containing only selected pages
+ */
+export async function extractPdfPages(
+  content: File | Blob | ArrayBuffer,
+  startPage: number,
+  endPage: number
+): Promise<Blob> {
+  let arrayBuffer: ArrayBuffer;
+
+  if (content instanceof ArrayBuffer) {
+    arrayBuffer = content;
+  } else {
+    arrayBuffer = await content.arrayBuffer();
+  }
+
+  const srcDoc = await PDFDocument.load(arrayBuffer);
+  const totalPages = srcDoc.getPageCount();
+
+  // Validate page range
+  const start = Math.max(1, Math.min(startPage, totalPages));
+  const end = Math.max(start, Math.min(endPage, totalPages));
+
+  // Convert to 0-indexed for pdf-lib
+  const pageIndices = Array.from(
+    { length: end - start + 1 },
+    (_, i) => start - 1 + i
+  );
+
+  // Create new document with only selected pages
+  const newDoc = await PDFDocument.create();
+  const copiedPages = await newDoc.copyPages(srcDoc, pageIndices);
+  copiedPages.forEach((page) => newDoc.addPage(page));
+
+  const pdfBytes = await newDoc.save();
+  return new Blob([pdfBytes], { type: 'application/pdf' });
+}
+
+/**
+ * Converts 1-indexed page range to 0-indexed array for Mistral API
+ * @param startPage Start page (1-indexed)
+ * @param endPage End page (1-indexed)
+ * @returns Array of 0-indexed page numbers
+ */
+export function pageRangeToMistralPages(
+  startPage: number,
+  endPage: number
+): number[] {
+  return Array.from(
+    { length: endPage - startPage + 1 },
+    (_, i) => startPage - 1 + i
+  );
+}

--- a/paper2llm-web/src/types/interfaces.ts
+++ b/paper2llm-web/src/types/interfaces.ts
@@ -19,6 +19,14 @@ export type {
 };
 
 /**
+ * Page range selection for PDF processing (1-indexed for UI display)
+ */
+export interface PageRange {
+  startPage: number;
+  endPage: number;
+}
+
+/**
  * Represents a PDF file that can be processed by the application.
  */
 export interface PdfFile {
@@ -29,6 +37,14 @@ export interface PdfFile {
   source: 'upload' | 'url';
   originalUrl?: string;
   directProcessUrl?: boolean; // indicates if URL can be processed directly by Mistral OCR
+}
+
+/**
+ * Extended PDF file information including page count and selected range
+ */
+export interface PdfFileWithPageInfo extends PdfFile {
+  pageCount?: number;
+  selectedPageRange?: PageRange;
 }
 
 /**
@@ -70,6 +86,10 @@ export interface FileUploaderState {
   error: string | null;
   isDragging: boolean;
   url: string;
+  pageCount: number | null;
+  pageRange: [number, number];
+  pageCountLoading: boolean;
+  pageCountError: string | null;
 }
 
 
@@ -95,6 +115,7 @@ export interface ApiKeyManagerState {
 export interface OcrOptions {
   model?: string;
   includeImageBase64?: boolean;
+  pages?: number[]; // 0-indexed page numbers to process (for Mistral API)
 }
 
 /**

--- a/paper2llm-web/src/web/App.tsx
+++ b/paper2llm-web/src/web/App.tsx
@@ -11,11 +11,9 @@ import {
   Container,
   Box,
   Paper,
-  Divider,
   Button,
   useTheme,
   FormControl,
-  FormHelperText,
   InputLabel,
   Select,
   MenuItem,
@@ -30,7 +28,7 @@ import ApiKeyManager from "./components/ApiKeyManager";
 import ProcessingStatus from "./components/ProcessingStatus";
 import MarkdownPreview from "./components/markdown-preview";
 import {
-  PdfFile,
+  PdfFileWithPageInfo,
   ProgressUpdate,
   PdfToMdResult,
   ApiProvider,
@@ -43,7 +41,7 @@ import { PROVIDER_INFO } from "./components/api-key-manager/constants";
 
 const App: React.FC = () => {
   const theme = useTheme();
-  const [pdfFile, setPdfFile] = useState<PdfFile | null>(null);
+  const [pdfFile, setPdfFile] = useState<PdfFileWithPageInfo | null>(null);
   const [apiKeys, setApiKeys] = useState<Record<ApiProvider, string>>({
     mistral: "",
     openai: "",
@@ -175,7 +173,7 @@ const App: React.FC = () => {
   };
 
   // Handle file selection
-  const handleFileSelected = useCallback((file: PdfFile) => {
+  const handleFileSelected = useCallback((file: PdfFileWithPageInfo) => {
     setPdfFile(file);
     setConversionResult(null);
     setProcessingError(null);
@@ -521,7 +519,7 @@ const App: React.FC = () => {
         }}
       >
         <Typography variant="body2" sx={{ mb: 1 }}>
-          © 2025 paper2llm v{packageInfo.version} - MIT License |{" "}
+          © 2025 paper2llm v{packageInfo.version} (updated {packageInfo.lastUpdated}) - MIT License |{" "}
           <a
             href="https://github.com/lacerbi/paper2llm"
             target="_blank"
@@ -547,6 +545,15 @@ const App: React.FC = () => {
             style={{ color: theme.palette.primary.main }}
           >
             X
+          </a>{" "}
+          |{" "}
+          <a
+            href="https://www.linkedin.com/in/luigi-acerbi-719b492/"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: theme.palette.primary.main }}
+          >
+            LinkedIn
           </a>{" "}
           |
           <a

--- a/paper2llm-web/src/web/components/ApiKeyManager.tsx
+++ b/paper2llm-web/src/web/components/ApiKeyManager.tsx
@@ -11,7 +11,6 @@ import {
   Grid,
   Stack,
   Chip,
-  SelectChangeEvent,
   CircularProgress,
 } from "@mui/material";
 import { Key as KeyIcon, Check as CheckIcon } from "@mui/icons-material";

--- a/paper2llm-web/src/web/components/FileUploader.tsx
+++ b/paper2llm-web/src/web/components/FileUploader.tsx
@@ -2,18 +2,17 @@
 // Handles both file uploads and URL inputs with validation, combining drag & drop and URL
 // input on the same row for a more compact interface.
 
-import React, { useState, useRef, useCallback, DragEvent, ChangeEvent } from 'react';
-import { 
-  Box, 
-  Paper, 
-  Typography, 
-  TextField, 
-  Button, 
-  Divider, 
-  Card, 
+import React, { useState, useRef, useCallback, useEffect, DragEvent, ChangeEvent } from 'react';
+import {
+  Box,
+  Paper,
+  Typography,
+  TextField,
+  Button,
+  Divider,
+  Card,
   CardContent,
   Alert,
-  IconButton, 
   useTheme,
   Grid,
   Container
@@ -22,11 +21,13 @@ import {
   CloudUpload as UploadIcon,
   InsertDriveFile as FileIcon
 } from '@mui/icons-material';
-import { FileUploaderState, PdfFile } from '../../types/interfaces';
+import { FileUploaderState, PdfFile, PdfFileWithPageInfo, PageRange } from '../../types/interfaces';
 import { webFileHandler } from '../../adapters/web/file-handler';
+import { getPdfPageCount } from '../../core/utils/pdf-page-utils';
+import PageRangeSelector from './PageRangeSelector';
 
 interface FileUploaderProps {
-  onFileSelected: (file: PdfFile) => void;
+  onFileSelected: (file: PdfFileWithPageInfo) => void;
 }
 
 const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected }) => {
@@ -37,9 +38,77 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected }) => {
     error: null,
     isDragging: false,
     url: '',
+    pageCount: null,
+    pageRange: [1, 1],
+    pageCountLoading: false,
+    pageCountError: null,
   });
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Detect page count after file is loaded
+  const detectPageCount = useCallback(async (pdfFile: PdfFile) => {
+    // For direct URL processing (e.g., arXiv), we can't count pages locally
+    if (pdfFile.directProcessUrl) {
+      setState(prev => ({
+        ...prev,
+        pageCount: null,
+        pageRange: [1, 1],
+        pageCountLoading: false,
+        pageCountError: null
+      }));
+      return;
+    }
+
+    setState(prev => ({ ...prev, pageCountLoading: true, pageCountError: null }));
+
+    try {
+      const result = await getPdfPageCount(pdfFile.content);
+
+      if (result.error) {
+        setState(prev => ({
+          ...prev,
+          pageCount: null,
+          pageCountError: result.error ?? null,
+          pageCountLoading: false
+        }));
+      } else {
+        setState(prev => ({
+          ...prev,
+          pageCount: result.pageCount,
+          pageRange: [1, result.pageCount],
+          pageCountLoading: false
+        }));
+      }
+    } catch (error) {
+      setState(prev => ({
+        ...prev,
+        pageCount: null,
+        pageCountError: error instanceof Error ? error.message : 'Failed to count pages',
+        pageCountLoading: false
+      }));
+    }
+  }, []);
+
+  // Handle page range change from slider
+  const handlePageRangeChange = useCallback((range: [number, number]) => {
+    setState(prev => ({ ...prev, pageRange: range }));
+  }, []);
+
+  // Notify parent when page range changes
+  useEffect(() => {
+    if (state.file && state.pageCount && state.pageCount > 1) {
+      const pageRange: PageRange = {
+        startPage: state.pageRange[0],
+        endPage: state.pageRange[1]
+      };
+      onFileSelected({
+        ...state.file,
+        pageCount: state.pageCount,
+        selectedPageRange: pageRange
+      });
+    }
+  }, [state.pageRange, state.file, state.pageCount, onFileSelected]);
 
   // Handle drag events
   const handleDragEnter = useCallback((e: DragEvent<HTMLDivElement>) => {
@@ -66,44 +135,60 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected }) => {
   const handleDrop = useCallback(async (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    
+
     setState(prev => ({ ...prev, isDragging: false, loading: true, error: null }));
-    
+
     if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
       const file = e.dataTransfer.files[0];
-      
+
       try {
         const pdfFile = await webFileHandler.readFile(file);
-        setState(prev => ({ ...prev, file: pdfFile, loading: false }));
-        onFileSelected(pdfFile);
+        setState(prev => ({
+          ...prev,
+          file: pdfFile,
+          loading: false,
+          pageCount: null,
+          pageRange: [1, 1],
+          pageCountError: null
+        }));
+        onFileSelected({ ...pdfFile, pageCount: undefined, selectedPageRange: undefined });
+        detectPageCount(pdfFile);
       } catch (error) {
-        setState(prev => ({ 
-          ...prev, 
-          loading: false, 
-          error: error instanceof Error ? error.message : 'Failed to process file' 
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: error instanceof Error ? error.message : 'Failed to process file'
         }));
       }
     }
-  }, [onFileSelected]);
+  }, [onFileSelected, detectPageCount]);
 
   // Handle file input change
   const handleFileChange = useCallback(async (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
       setState(prev => ({ ...prev, loading: true, error: null }));
-      
+
       try {
         const pdfFile = await webFileHandler.readFile(e.target.files[0]);
-        setState(prev => ({ ...prev, file: pdfFile, loading: false }));
-        onFileSelected(pdfFile);
+        setState(prev => ({
+          ...prev,
+          file: pdfFile,
+          loading: false,
+          pageCount: null,
+          pageRange: [1, 1],
+          pageCountError: null
+        }));
+        onFileSelected({ ...pdfFile, pageCount: undefined, selectedPageRange: undefined });
+        detectPageCount(pdfFile);
       } catch (error) {
-        setState(prev => ({ 
-          ...prev, 
-          loading: false, 
-          error: error instanceof Error ? error.message : 'Failed to process file' 
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: error instanceof Error ? error.message : 'Failed to process file'
         }));
       }
     }
-  }, [onFileSelected]);
+  }, [onFileSelected, detectPageCount]);
 
   // Handle URL input
   const handleUrlChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
@@ -113,26 +198,34 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected }) => {
   // Process URL submission
   const handleUrlSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!state.url.trim()) {
       setState(prev => ({ ...prev, error: 'Please enter a URL' }));
       return;
     }
 
     setState(prev => ({ ...prev, loading: true, error: null }));
-    
+
     try {
       const pdfFile = await webFileHandler.fetchFromUrl(state.url);
-      setState(prev => ({ ...prev, file: pdfFile, loading: false }));
-      onFileSelected(pdfFile);
+      setState(prev => ({
+        ...prev,
+        file: pdfFile,
+        loading: false,
+        pageCount: null,
+        pageRange: [1, 1],
+        pageCountError: null
+      }));
+      onFileSelected({ ...pdfFile, pageCount: undefined, selectedPageRange: undefined });
+      detectPageCount(pdfFile);
     } catch (error) {
-      setState(prev => ({ 
-        ...prev, 
-        loading: false, 
-        error: error instanceof Error ? error.message : 'Failed to fetch PDF from URL' 
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        error: error instanceof Error ? error.message : 'Failed to fetch PDF from URL'
       }));
     }
-  }, [state.url, onFileSelected]);
+  }, [state.url, onFileSelected, detectPageCount]);
 
   // Trigger file selection dialog
   const handleSelectFile = () => {
@@ -334,14 +427,14 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected }) => {
               </Typography>
             </Box>
             <Typography variant="body2" sx={{ mb: 1 }}>
-              <strong>Size:</strong> {state.file.source === 'url' ? 'N/A' : `${(state.file.size / 1024 / 1024).toFixed(2)} MB`} | 
+              <strong>Size:</strong> {state.file.source === 'url' ? 'N/A' : `${(state.file.size / 1024 / 1024).toFixed(2)} MB`} |
               <strong> Source:</strong> {state.file.source === 'upload' ? 'Local Upload' : 'URL'}
               {state.file.originalUrl && (
-                <> | <a 
+                <> | <a
                   href={state.file.originalUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  style={{ 
+                  style={{
                     color: theme.palette.primary.main,
                     textDecoration: 'none',
                     wordBreak: 'break-all'
@@ -352,6 +445,15 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected }) => {
                 </>
               )}
             </Typography>
+
+            {/* Page Range Selector */}
+            <PageRangeSelector
+              pageCount={state.pageCount}
+              pageRange={state.pageRange}
+              onPageRangeChange={handlePageRangeChange}
+              isLoading={state.pageCountLoading}
+              error={state.pageCountError}
+            />
           </CardContent>
         </Card>
       )}

--- a/paper2llm-web/src/web/components/PageRangeSelector.tsx
+++ b/paper2llm-web/src/web/components/PageRangeSelector.tsx
@@ -1,0 +1,158 @@
+// AI Summary: Component for selecting page range in multi-page PDFs using dual-thumb slider.
+// Shows total page count and allows users to select start/end pages for processing.
+
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Slider,
+  Stack,
+  TextField,
+  Chip,
+  CircularProgress,
+  Alert
+} from '@mui/material';
+import { Description as PageIcon } from '@mui/icons-material';
+
+interface PageRangeSelectorProps {
+  pageCount: number | null;
+  pageRange: [number, number];
+  onPageRangeChange: (range: [number, number]) => void;
+  isLoading?: boolean;
+  error?: string | null;
+  disabled?: boolean;
+}
+
+const PageRangeSelector: React.FC<PageRangeSelectorProps> = ({
+  pageCount,
+  pageRange,
+  onPageRangeChange,
+  isLoading = false,
+  error = null,
+  disabled = false
+}) => {
+  // Show loading state
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1 }}>
+        <CircularProgress size={16} />
+        <Typography variant="body2" color="text.secondary">
+          Detecting page count...
+        </Typography>
+      </Box>
+    );
+  }
+
+  // Show error if page count detection failed
+  if (error) {
+    return (
+      <Alert severity="warning" sx={{ mt: 1 }}>
+        Could not detect page count: {error}. All pages will be processed.
+      </Alert>
+    );
+  }
+
+  // Don't show selector if page count unknown
+  if (!pageCount || pageCount <= 0) {
+    return null;
+  }
+
+  // For single-page PDFs, just show info text
+  if (pageCount === 1) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+        <PageIcon fontSize="small" color="action" />
+        <Typography variant="body2" color="text.secondary">
+          1 page
+        </Typography>
+      </Box>
+    );
+  }
+
+  // Multi-page PDF: show slider
+  const handleSliderChange = (_event: Event, newValue: number | number[]) => {
+    if (Array.isArray(newValue) && newValue.length === 2) {
+      onPageRangeChange([newValue[0], newValue[1]]);
+    }
+  };
+
+  const handleStartInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Math.max(1, Math.min(Number(event.target.value) || 1, pageRange[1]));
+    onPageRangeChange([value, pageRange[1]]);
+  };
+
+  const handleEndInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Math.max(pageRange[0], Math.min(Number(event.target.value) || pageCount, pageCount));
+    onPageRangeChange([pageRange[0], value]);
+  };
+
+  const selectedCount = pageRange[1] - pageRange[0] + 1;
+  const isFullRange = pageRange[0] === 1 && pageRange[1] === pageCount;
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <PageIcon fontSize="small" />
+          {pageCount} pages total
+        </Typography>
+        <Chip
+          label={isFullRange ? 'All pages' : `${selectedCount} of ${pageCount} pages`}
+          size="small"
+          color={isFullRange ? 'default' : 'primary'}
+          variant="outlined"
+        />
+      </Box>
+
+      <Box sx={{ px: 1 }}>
+        <Slider
+          value={pageRange}
+          onChange={handleSliderChange}
+          min={1}
+          max={pageCount}
+          step={1}
+          marks={pageCount <= 20 ? true : [
+            { value: 1, label: '1' },
+            { value: pageCount, label: String(pageCount) }
+          ]}
+          valueLabelDisplay="auto"
+          getAriaLabel={() => 'Page range'}
+          getAriaValueText={(value) => `Page ${value}`}
+          disabled={disabled}
+          disableSwap
+          sx={{
+            '& .MuiSlider-markLabel': {
+              fontSize: '0.75rem'
+            }
+          }}
+        />
+      </Box>
+
+      <Stack direction="row" spacing={2} sx={{ mt: 1 }} alignItems="center">
+        <TextField
+          label="From"
+          type="number"
+          size="small"
+          value={pageRange[0]}
+          onChange={handleStartInputChange}
+          disabled={disabled}
+          inputProps={{ min: 1, max: pageRange[1] }}
+          sx={{ width: 80 }}
+        />
+        <Typography variant="body2" color="text.secondary">to</Typography>
+        <TextField
+          label="To"
+          type="number"
+          size="small"
+          value={pageRange[1]}
+          onChange={handleEndInputChange}
+          disabled={disabled}
+          inputProps={{ min: pageRange[0], max: pageCount }}
+          sx={{ width: 80 }}
+        />
+      </Stack>
+    </Box>
+  );
+};
+
+export default PageRangeSelector;

--- a/paper2llm-web/src/web/components/ProcessingStatus.tsx
+++ b/paper2llm-web/src/web/components/ProcessingStatus.tsx
@@ -2,24 +2,23 @@
 // Shows stages with icons, animated progress indicators, and detailed error handling with recovery options.
 
 import React, { useState, useEffect } from 'react';
-import { 
-  Box, 
-  Card, 
-  CardContent, 
-  Typography, 
-  LinearProgress, 
-  Button, 
-  Alert, 
-  AlertTitle, 
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  LinearProgress,
+  Button,
+  Alert,
+  AlertTitle,
   Stack,
   Chip,
   Divider,
   Collapse,
   IconButton,
-  Paper,
-  TextField
+  Paper
 } from '@mui/material';
-import { 
+import {
   CloudUpload as UploadIcon,
   Settings as ProcessingIcon,
   CloudDownload as DownloadIcon,
@@ -31,7 +30,6 @@ import {
   Cancel as CancelIcon,
   Replay as RetryIcon,
   ExpandMore as ExpandMoreIcon,
-  Code as CodeIcon,
   ContentCopy as CopyIcon,
   VisibilityOff as VisibilityOffIcon,
   Visibility as VisibilityIcon

--- a/paper2llm-web/src/web/components/api-key-manager/ApiKeyInput.tsx
+++ b/paper2llm-web/src/web/components/api-key-manager/ApiKeyInput.tsx
@@ -2,14 +2,7 @@
 // Displays masked or visible API key with appropriate input controls and provider documentation link.
 
 import React from "react";
-import {
-  TextField,
-  InputAdornment,
-  IconButton,
-  FormHelperText,
-  Tooltip,
-  useTheme,
-} from "@mui/material";
+import { TextField, InputAdornment, IconButton, Tooltip } from "@mui/material";
 import {
   Visibility as VisibilityIcon,
   VisibilityOff as VisibilityOffIcon,
@@ -45,8 +38,6 @@ const ApiKeyInput: React.FC<ApiKeyInputProps> = ({
   onChange,
   onToggleVisibility,
 }) => {
-  const theme = useTheme();
-
   return (
     <>
       <TextField

--- a/paper2llm-web/src/web/components/api-key-manager/ErrorMessage.tsx
+++ b/paper2llm-web/src/web/components/api-key-manager/ErrorMessage.tsx
@@ -13,7 +13,6 @@ import {
   Error as ErrorIcon
 } from '@mui/icons-material';
 import { ApiProvider } from '../../../types/interfaces';
-import { ApiKeyExpiration } from '../../../types/interfaces';
 
 interface ErrorMessageProps {
   error: string | null;

--- a/paper2llm-web/src/web/components/markdown-preview/MarkdownPreview.tsx
+++ b/paper2llm-web/src/web/components/markdown-preview/MarkdownPreview.tsx
@@ -17,7 +17,6 @@ import {
   Grid,
 } from "@mui/material";
 import { DescriptionOutlined as MarkdownIcon } from "@mui/icons-material";
-import { PdfToMdResult } from "../../../types/interfaces";
 import { MarkdownPreviewProps } from "./types";
 import { calculateImageMetrics } from "./utils/content-utils";
 import { useMarkdownSections } from "./hooks/useMarkdownSections";

--- a/paper2llm-web/src/web/components/markdown-preview/hooks/useCopyDownload.ts
+++ b/paper2llm-web/src/web/components/markdown-preview/hooks/useCopyDownload.ts
@@ -3,10 +3,7 @@
 
 import { useState } from "react";
 import { MarkdownSections } from "../../../../core/utils/markdown-splitter";
-import {
-  PdfToMdResult,
-  BibTeXTitleValidation,
-} from "../../../../types/interfaces";
+import { PdfToMdResult } from "../../../../types/interfaces";
 import {
   generateBibTeXFromMarkdown,
   BibTeXGenerationResult,

--- a/paper2llm-web/src/web/components/markdown-preview/utils/content-utils.ts
+++ b/paper2llm-web/src/web/components/markdown-preview/utils/content-utils.ts
@@ -4,7 +4,7 @@
 import { MarkdownSections } from "../../../../core/utils/markdown-splitter";
 import { generateBibTeXFromMarkdown, BibTeXGenerationResult } from "../../../../core/utils/bibtex-generator";
 import { SectionType, ImageMetrics } from "../types";
-import { PdfToMdResult, BibTeXTitleValidation } from "../../../../types/interfaces";
+import { PdfToMdResult } from "../../../../types/interfaces";
 
 /**
  * Gets content for a specific section of the markdown document


### PR DESCRIPTION
## Summary

- **PDF Page Range Selection**: Users can now select which pages to process from multi-page PDFs using a dual-slider UI
- **Dual Processing Strategy**: Local uploads extract only selected pages (privacy-preserving), URL-based PDFs use Mistral's `pages` API parameter
- **Security Fixes**: Resolved npm vulnerabilities in axios, glob, js-yaml, mdast-util-to-hast, and node-forge
- **Maintenance**: Various updates to API storage, image services, and components

## New Features

### Page Range Selection
- Displays total page count after PDF is selected
- Dual-thumb slider for selecting start/end pages
- Shows "X of Y pages selected" indicator
- Single-page PDFs show "1 page" text (no slider)
- Graceful handling of corrupted/unreadable PDFs

### Privacy-Preserving Page Extraction
- **Local uploads**: Uses `pdf-lib` to extract only selected pages before sending to Mistral (unselected pages never leave your device)
- **URL-based PDFs**: Passes `pages` parameter to Mistral API

## Dependencies
- Added `pdf-lib` for client-side PDF manipulation
- Updated various dependencies to fix security vulnerabilities

## Test plan
- [ ] Upload a multi-page PDF and verify page count is displayed
- [ ] Use slider to select a page range and process
- [ ] Test with single-page PDF (should show "1 page", no slider)
- [ ] Test with URL-based PDF (e.g., arXiv)
- [ ] Verify production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)